### PR TITLE
Improve curve editor UX, tighten target window handling, and reorganize run storage

### DIFF
--- a/csce483CapstoneFall2025-main/backend/optimization_process.py
+++ b/csce483CapstoneFall2025-main/backend/optimization_process.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 from typing import Optional
 from backend.curvefit_optimization import (
-    calculate_session_paths,
+    calculate_session_paths_v2,
     curvefit_optimize,
     get_current_session_number,
     AbortOptimization,
@@ -143,7 +143,7 @@ def add_node_constraints(constraints, analysis_type="transient", ac_response="ma
 
 def optimizeProcess(queue, curveData, testRows, netlistPath, netlistObject, selectedParameters, optimizationTolerances, RLCBounds, xyce_executable_path=None, stop_event: Optional[Event] = None):
     original_netlist_path = getattr(netlistObject, "file_path", netlistPath)
-    session_num = get_current_session_number()
+    session_num = get_current_session_number(original_netlist_path)
 
     def _check_abort():
         if stop_event and stop_event.is_set():
@@ -250,7 +250,7 @@ def optimizeProcess(queue, curveData, testRows, netlistPath, netlistObject, sele
             x_parameter = "FREQ" if analysis_type in {"ac", "noise"} else "TIME"
         x_parameter = str(x_parameter).strip().upper()
 
-        _, group_dir, session_dir = calculate_session_paths(session_num, "runs")
+        _, group_dir, session_dir = calculate_session_paths_v2(session_num, netlist_path=original_netlist_path)
         os.makedirs(session_dir, exist_ok=True)
         WRITABLE_NETLIST_PATH = os.path.join(session_dir, "optimized.txt")
 
@@ -446,6 +446,7 @@ def optimizeProcess(queue, curveData, testRows, netlistPath, netlistObject, sele
             xyce_executable_path=xyce_executable_path,
             stop_event=stop_event,
             session_num=session_num,
+            netlist_path=ORIG_NETLIST_PATH,
         )
 
         NETLIST.file_path = ORIG_NETLIST_PATH

--- a/csce483CapstoneFall2025-main/frontend/netlist_uploader.py
+++ b/csce483CapstoneFall2025-main/frontend/netlist_uploader.py
@@ -100,11 +100,52 @@ class NetlistUploaderWindow(tk.Frame):
         self.continue_button.configure(state=tk.DISABLED)
         self.continue_button.pack(side=tk.RIGHT)
 
+    def _reset_session_state(self) -> None:
+        """Clear shared state that should not leak between different netlists."""
+        defaults = {
+            "selected_parameters": [],
+            "netlist_object": None,
+            "netlist_includes": [],
+            "generated_data": [],
+            "optimization_results": None,
+            "optimization_settings": {},
+            "pending_start": False,
+            "nodes": set(),
+            "source_names": [],
+            "analysis_type": "transient",
+            "ac_settings": {
+                "sweep_type": "DEC",
+                "points": 10,
+                "start_frequency": 1.0,
+                "stop_frequency": 1e6,
+                "response": "magnitude",
+            },
+            "tran_settings": {
+                "tstop": None,
+                "tstep": None,
+                "tstart": None,
+                "max_step": None,
+                "uic": False,
+            },
+            "noise_settings": {
+                "sweep_type": "DEC",
+                "points": 10,
+                "start_frequency": 1.0,
+                "stop_frequency": 1e6,
+                "output_node": "",
+                "input_source": "",
+                "quantity": "onoise",
+            },
+        }
+        for key, value in defaults.items():
+            self.controller.update_app_data(key, value)
+
     def upload_netlist(self) -> None:
         """Handles the netlist upload process."""
         file_path = open_file_dialog()
         if file_path:
             self.netlist_path = file_path
+            self._reset_session_state()
             self.controller.update_app_data("netlist_path", self.netlist_path)
             self.status_label.config(
                 text=f"Netlist ready: {self.netlist_path}",

--- a/csce483CapstoneFall2025-main/frontend/optimization_settings/visual_curve_editors.py
+++ b/csce483CapstoneFall2025-main/frontend/optimization_settings/visual_curve_editors.py
@@ -343,10 +343,11 @@ def open_heaviside_editor(owner, a_init, t0_init, x1_init, on_change=None, on_ap
 # ------------------------
 # PIECEWISE-LINEAR editor
 # ------------------------
-def open_piecewise_editor(owner, pts_init, on_change=None, on_save_constraint=None, axis_labels=None, constraint_left_options=None, current_y_signal=None):
+def open_piecewise_editor(owner, pts_init, on_change=None, on_apply=None, on_save_constraint=None, axis_labels=None, constraint_left_options=None, current_y_signal=None):
     """
     pts_init : list[(x,y)]
     on_change(new_pts) called whenever points change (drag, insert, remove, apply)
+    on_apply(new_pts) called when the user clicks Apply/Use in target
     """
     win = tk.Toplevel(owner)
     win.title("Piecewise Linear Editor")
@@ -381,6 +382,7 @@ def open_piecewise_editor(owner, pts_init, on_change=None, on_save_constraint=No
     autoscale = tk.BooleanVar(value=True)  # NEW: default ON for PWL
     ttk.Checkbutton(bar, text="Auto-rescale", variable=autoscale, style="TCheckbutton").pack(side=tk.LEFT, padx=(4,6))  # NEW
     ttk.Button(bar, text="Fit", command=lambda: _redraw(rescale=True, emit=False), style="Secondary.TButton").pack(side=tk.LEFT, padx=(2,10))  # NEW
+    create_primary_button(bar, text="Apply to Target", command=lambda: _apply_current()).pack(side=tk.RIGHT, padx=(8, 0))
 
     bar = LegacyConstraintsBar(
         parent=win,                         # or the frame/shell holding your buttons
@@ -469,6 +471,11 @@ def open_piecewise_editor(owner, pts_init, on_change=None, on_save_constraint=No
 
     def _emit():
         if on_change: on_change(list(pts))
+
+    def _apply_current():
+        _emit()
+        if callable(on_apply):
+            on_apply(list(pts))
 
     def _selected_index():
         sel = table.selection()

--- a/csce483CapstoneFall2025-main/frontend/optimization_summary.py
+++ b/csce483CapstoneFall2025-main/frontend/optimization_summary.py
@@ -746,11 +746,12 @@ class OptimizationSummary(tk.Frame):
 
     def _history_available(self) -> bool:
         """Determine if there is any history to show."""
-        runs_dir = "runs"
+        runs_dir = os.path.abspath(os.environ.get("XYCLOPS_WORKSPACE") or "runs")
+        results_root = os.path.join(runs_dir, "netlist-results")
         has_runs = False
         try:
-            if os.path.exists(runs_dir):
-                has_runs = any(os.scandir(runs_dir))
+            if os.path.exists(results_root):
+                has_runs = any(os.scandir(results_root))
         except OSError:
             has_runs = False
         return self.controller.get_app_data("optimization_results") is not None or has_runs


### PR DESCRIPTION
- add one-click “Apply to Target” path for piecewise editor, make visual editor button mode-aware and default-visible so users can find it
- clear stale state on new netlist upload (params, tran/noise/ac settings, generated data) to avoid leaking old runs
- store sessions under workspace-aware XYCLOPS_WORKSPACE, netlist-results/<netlist>/<session> and update history/summary to read the same layout
- constrain residuals and node checks to the target time/frequency window, downsample dense Xyce output for plots, and surface Xyce launch failures with executable path for Windows
- ensure node constraint evaluation uses window-masked data to avoid false penalties